### PR TITLE
PR: Add An Image w/ NVIDIA Omniverse Launcher

### DIFF
--- a/dockerfiles/platform/Dockerfile.nvidia-omniverse
+++ b/dockerfiles/platform/Dockerfile.nvidia-omniverse
@@ -1,0 +1,40 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE} as build
+ARG NVIDIA_OMNIVERSE_LAUNCHER_VERSION
+ARG REPOSITORY_PATH="/opt/repositories"
+ARG NVIDIA_OMNIVERSE_LAUNCHER_PATH
+USER root
+RUN echo 'export PATH=$PATH:/home/robolaunch/.local/bin' >> ~/.bashrc
+RUN mkdir -p ${REPOSITORY_PATH}/nvidia-omniverse-launcher /home/robolaunch/.local/share/applications /home/robolaunch/.config/xfce4/panel/launcher-21
+
+WORKDIR ${REPOSITORY_PATH}/nvidia-omniverse-launcher
+COPY ${NVIDIA_OMNIVERSE_LAUNCHER_PATH}/omniverse-launcher-linux.AppImage .
+COPY ${NVIDIA_OMNIVERSE_LAUNCHER_PATH}/applications.tar.gz /home/robolaunch/.local/share/
+# COPY ${NVIDIA_OMNIVERSE_LAUNCHER_PATH}/launcher-21 /home/robolaunch/.config/xfce4/panel/launcher-21
+
+# extract tar.gz
+WORKDIR /home/robolaunch/.local/share/
+RUN set -eux; \
+    tar -xvzf applications.tar.gz
+
+WORKDIR ${REPOSITORY_PATH}/nvidia-omniverse-launcher
+
+# install dependencies
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y wget xdg-utils fuse gnome-terminal fonts-liberation
+
+# install chrome
+RUN set -eux; \
+    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb; \
+    dpkg -i google-chrome-stable_current_amd64.deb
+
+# install & configure NVIDIA Omniverse Launcher
+RUN set -eux; \
+    chmod +x omniverse-launcher-linux.AppImage; \
+    ./omniverse-launcher-linux.AppImage --appimage-extract; \
+    update-desktop-database /home/robolaunch/.local/share/applications/; \
+    xdg-mime default nvidia-omniverse-launcher.desktop x-scheme-handler/omniverse-launcher; \
+    chmod -w /home/robolaunch/.local/share/applications/nvidia-omniverse-launcher.desktop   
+
+WORKDIR /home/robolaunch

--- a/pipelines/platform/nvidia-omniverse.yaml
+++ b/pipelines/platform/nvidia-omniverse.yaml
@@ -1,0 +1,17 @@
+name: nvidia-omniverse-jammy
+registry: docker.io
+organization: robolaunchio
+version: 0.1.0-beta.02
+steps:
+- name: nvidia-omniverse
+  image:
+    repository: devspace-platform
+    tag: nvidia-omniverse-1.9.13-jammy-xfce-amd64
+  context: dockerfiles/platform
+  path: "."
+  dockerfile: "Dockerfile.nvidia-omniverse"
+  buildArgs:
+    "BASE_IMAGE": "robolaunchio/devspace:plain-0.1.0-jammy-xfce-amd64-cuda-12.2.2-0.1.0-beta.02"
+    "NVIDIA_OMNIVERSE_LAUNCHER_VERSION": "1.9.13"
+    "NVIDIA_OMNIVERSE_LAUNCHER_PATH": "."
+  push: true


### PR DESCRIPTION
# :herb: PR: Add An Image w/ NVIDIA Omniverse Launcher

## Description

Launcher can be started by running `/opt/repositories/nvidia-omniverse-launcher/squashfs-root/omniverse-launcher`.

Closes #5 

## Type of change

- [x] This change requires a documentation update

## How can it be tested?

Can be tested by running the pipeline.
